### PR TITLE
Topic/grid

### DIFF
--- a/for_3.2/sub_parts_image/sub_parts_image.rb
+++ b/for_3.2/sub_parts_image/sub_parts_image.rb
@@ -190,9 +190,7 @@ Plugin.create :sub_parts_image do
         [icon, image_draw_area(pos, canvas_width)]
       }.each { |icon, rect|
         context.save {
-          width_ratio = Rational(rect.width, icon.width)
-          height_ratio = Rational(rect.height, icon.height)
-          scale_xy = [height_ratio, width_ratio].min
+          scale_xy = [Rational(rect.width, icon.width), Rational(rect.height, icon.height)].min
 
           context.translate((rect.width - icon.width * scale_xy) / 2, rect.y)
           context.scale(scale_xy, scale_xy)

--- a/for_3.2/sub_parts_image/sub_parts_image.rb
+++ b/for_3.2/sub_parts_image/sub_parts_image.rb
@@ -170,11 +170,25 @@ Plugin.create :sub_parts_image do
       end
     end
 
+    def aspect_ratio(pos)
+      case @num
+      when 1, 4
+        Rational(16, 9)
+      when 2
+        Rational(1, 1)
+      when 3
+        if pos == 0
+          Rational(6, 9)
+        else
+          Rational(20, 9) end
+      else
+        Rational(16, 9) end end
+
     def aspect_ratio_x(pos)
-      16 end
+      aspect_ratio(pos).numerator end
 
     def aspect_ratio_y(pos)
-      9 end
+      aspect_ratio(pos).denominator end
 
     # 画像を描画する座標とサイズを返す
     # ==== Args
@@ -183,11 +197,30 @@ Plugin.create :sub_parts_image do
     # ==== Return
     # Gdk::Rectangle その画像を描画する場所
     def image_draw_area(pos, canvas_width)
-      height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * canvas_width
-      Gdk::Rectangle.new(0,
-                         height * pos,
-                         canvas_width,
-                         height)
+      case @num
+      when 1
+        height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * canvas_width
+        Gdk::Rectangle.new(0, height * pos, canvas_width, height)
+      when 2
+        width = canvas_width/2
+        height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * width
+        Gdk::Rectangle.new(width * pos, 0, width, height)
+      when 3
+        if pos == 0
+          width = Rational(6,16) * canvas_width
+          height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * width
+          Gdk::Rectangle.new(0, 0, width, height)
+        else
+          x = Rational(6,16) * canvas_width
+          width = canvas_width - x
+          height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * width
+          Gdk::Rectangle.new(x, height * (pos-1), width, height)
+        end
+      else
+        width = canvas_width/2
+        height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * width
+        Gdk::Rectangle.new(width * (pos % 2), height * (pos/2).floor, width, height)
+      end
     end
 
     # 画像を切り抜くさい、どこを切り抜くかを返す

--- a/for_3.2/sub_parts_image/sub_parts_image.rb
+++ b/for_3.2/sub_parts_image/sub_parts_image.rb
@@ -186,27 +186,25 @@ Plugin.create :sub_parts_image do
     # サブパーツを描画
     def render(context)
       canvas_width = context.clip_extents[2]
-      Array(@main_icons).map.with_index { |icon, pos|
+      @main_icons.compact.map.with_index { |icon, pos|
         [icon, image_draw_area(pos, canvas_width)]
       }.each { |icon, rect|
-        if icon
-          context.save {
-            width_ratio = Rational(rect.width, icon.width)
-            height_ratio = Rational(rect.height, icon.height)
-            scale_xy = [height_ratio, width_ratio].min
+        context.save {
+          width_ratio = Rational(rect.width, icon.width)
+          height_ratio = Rational(rect.height, icon.height)
+          scale_xy = [height_ratio, width_ratio].min
 
-            context.translate((rect.width - icon.width * scale_xy) / 2, rect.y)
-            context.scale(scale_xy, scale_xy)
-            context.set_source_pixbuf(icon)
+          context.translate((rect.width - icon.width * scale_xy) / 2, rect.y)
+          context.scale(scale_xy, scale_xy)
+          context.set_source_pixbuf(icon)
 
-            context.clip {
-              round = Rational(UserConfig[:subparts_image_round], scale_xy)
-              context.rounded_rectangle(0, 0, icon.width, icon.height, round)
-            }
-
-            context.paint(UserConfig[:subparts_image_tp] / 100.0)
+          context.clip {
+            round = Rational(UserConfig[:subparts_image_round], scale_xy)
+            context.rounded_rectangle(0, 0, icon.width, icon.height, round)
           }
-        end
+
+          context.paint(UserConfig[:subparts_image_tp] / 100.0)
+        }
       }
     end
 

--- a/for_3.2/sub_parts_image/sub_parts_image.rb
+++ b/for_3.2/sub_parts_image/sub_parts_image.rb
@@ -104,15 +104,16 @@ Plugin.create :sub_parts_image do
             offset += part.height
           }
 
-          @num.times { |i|
-            # イメージをクリックした
-            if (offset + (i * UserConfig[:subparts_image_height])) <= y && (offset + ((i + 1) * UserConfig[:subparts_image_height])) >= y
-              case e.button
-              when 1
-                Plugin.call(:openimg_open, urls[i])
-              end
-            end
-          }
+          clicked_url, = urls.lazy.with_index.map{|url, pos|
+            rect = image_draw_area(pos, self.width)
+            [url, rect.x ... rect.x+rect.width, rect.y+offset ... rect.y+offset+rect.height]
+          }.find{|url, xrange, yrange|
+            xrange.include?(x) and yrange.include?(y) }
+          case e.button
+          when 1
+            Plugin.call(:openimg_open, clicked_url) if clicked_url
+          end
+
         }
       end
     end
@@ -180,15 +181,20 @@ Plugin.create :sub_parts_image do
         if pos == 0
           Rational(6, 9)
         else
-          Rational(20, 9) end
+          Rational(20, 9)
+        end
       else
-        Rational(16, 9) end end
+        Rational(16, 9)
+      end
+    end
 
     def aspect_ratio_x(pos)
-      aspect_ratio(pos).numerator end
+      aspect_ratio(pos).numerator
+    end
 
     def aspect_ratio_y(pos)
-      aspect_ratio(pos).denominator end
+      aspect_ratio(pos).denominator
+    end
 
     # 画像を描画する座標とサイズを返す
     # ==== Args
@@ -199,26 +205,26 @@ Plugin.create :sub_parts_image do
     def image_draw_area(pos, canvas_width)
       case @num
       when 1
-        height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * canvas_width
+        height = 1/aspect_ratio(pos) * canvas_width
         Gdk::Rectangle.new(0, height * pos, canvas_width, height)
       when 2
         width = canvas_width/2
-        height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * width
+        height = 1/aspect_ratio(pos) * width
         Gdk::Rectangle.new(width * pos, 0, width, height)
       when 3
         if pos == 0
           width = Rational(6,16) * canvas_width
-          height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * width
+          height = 1/aspect_ratio(pos) * width
           Gdk::Rectangle.new(0, 0, width, height)
         else
           x = Rational(6,16) * canvas_width
           width = canvas_width - x
-          height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * width
+          height = 1/aspect_ratio(pos) * width
           Gdk::Rectangle.new(x, height * (pos-1), width, height)
         end
       else
         width = canvas_width/2
-        height = Rational(aspect_ratio_y(pos), aspect_ratio_x(pos)) * width
+        height = 1/aspect_ratio(pos) * width
         Gdk::Rectangle.new(width * (pos % 2), height * (pos/2).floor, width, height)
       end
     end


### PR DESCRIPTION
Twitterみたいな感じでサムネイルを並べるやつを作ってみました。良かったら検討してもらえると有難いです。枚数が増えると１ツイートがとても長くなってしまうので、せいぜい16:9に収まるようになればいいなとおもってやりました。

![20151004-165919](https://cloud.githubusercontent.com/assets/586906/10266993/cdc8aa68-6ab9-11e5-8d65-7bdcdeefdfc5.png)

Twitterにならって、cropしてます。

- 1枚の場合
横幅をめいいっぱい使い、16:9

- 2枚の場合
一辺が横幅の半分の正方形

- 3枚の場合
１枚目は左に2:3、二枚目以降は20:9

- 4枚以上の場合
16:9で横2つずつ並べる

設定項目にマージンをつけて、画像の間のスペースを設定できるようにしてます。
また、高さは画像の比率で決まるので、設定から削除しました。