### PR TITLE
gtk2 3.0.9の仕様変更に対応

### DIFF
--- a/mikutter-subparts-image.rb
+++ b/mikutter-subparts-image.rb
@@ -190,10 +190,10 @@ Plugin.create :"mikutter-subparts-image" do
           streams.each.with_index do |pair, index|
             _, stream = *pair
             Thread.new {
-              pixbuf = Gdk::PixbufLoader.open{ |loader|
-                loader.write(stream.read)
-                stream.close
-              }.pixbuf
+              loader = Gdk::PixbufLoader.new
+              loader.last_write(stream.read)
+              stream.close
+              pixbuf = loader.pixbuf
 
               Delayer.new {
                 on_image_loaded(index, pixbuf)


### PR DESCRIPTION
gtk2 3.0.9でGdk::PixbufLoader.openが無くなったようなので使わないように変更しました。
mikutter 3.4.3で動作確認しました。

これで#6 が解決するかもしれません。
