### PR TITLE
Gdk::SubPartsのresistはdeprecatedなのでresisterに修正しました

### DIFF
--- a/mikutter-subparts-image.rb
+++ b/mikutter-subparts-image.rb
@@ -39,7 +39,7 @@ Plugin.create :"mikutter-subparts-image" do
 
   # サブパーツ
   class Gdk::SubPartsImage < Gdk::SubParts
-    regist
+    register
 
     # クリック位置の特定
     def get_pointed_image_pos(x, y)


### PR DESCRIPTION
mikutterの `core/mui/cairo_sub_parts_helper.rb` の57行目にdeprecatedの旨が書いてあります。