### PR TITLE
MiraclePainterが添付画像取得中に削除された時に描画を試みない

### DIFF
--- a/mikutter-subparts-image.rb
+++ b/mikutter-subparts-image.rb
@@ -90,7 +90,7 @@ Plugin.create :"mikutter-subparts-image" do
 
     # 画像URLが解決したタイミング
     def on_image_information(urls)
-      if urls.length == 0
+      if urls.empty? || helper.destroyed?
         return
       end
 
@@ -98,64 +98,55 @@ Plugin.create :"mikutter-subparts-image" do
         @num = urls.length
 
         if @height_reported
-          Delayer.new {
-            helper.reset_height
-          }
+          helper.reset_height
         end
       }
 
-      if !helper.destroyed?
-        # クリックイベント
-        @ignore_event = false
+      # クリックイベント
+      @ignore_event = false
 
-        if @click_sid
-          helper.signal_handler_disconnect(@click_sid)
-          @click_sid = nil
-        end
-
-        @click_sid = helper.ssc(:click) { |this, e, x, y|
-          pos = get_pointed_image_pos(x, y)
-
-          if pos
-            clicked_url = urls[pos]
-
-            case e.button
-            when 1
-              Plugin.call(:openimg_open, clicked_url) if clicked_url
-            end
-          end
-        }
-
-        if @motion_sid
-          helper.signal_handler_disconnect(@motion_sid)
-          @motion_sid = nil
-        end
-
-        @motion_event = helper.ssc(:motion_notify_event) { |this, x, y|
-          pos = get_pointed_image_pos(x, y)
-
-          if @draw_pos != pos
-            @draw_pos = pos
-
-            Delayer.new {
-              helper.on_modify
-            }
-          end
-        }
-
-        if @leave_sid
-          helper.signal_handler_disconnect(@leave_sid)
-          @leave_sid = nil
-        end
-
-        @leave_sid = helper.ssc(:leave_notify_event) { |this|
-          @draw_pos = nil
-
-          Delayer.new {
-            helper.on_modify
-          }
-        }
+      if @click_sid
+        helper.signal_handler_disconnect(@click_sid)
+        @click_sid = nil
       end
+
+      @click_sid = helper.ssc(:click) { |this, e, x, y|
+        pos = get_pointed_image_pos(x, y)
+
+        if pos
+          clicked_url = urls[pos]
+
+          case e.button
+          when 1
+            Plugin.call(:openimg_open, clicked_url) if clicked_url
+          end
+        end
+      }
+
+      if @motion_sid
+        helper.signal_handler_disconnect(@motion_sid)
+        @motion_sid = nil
+      end
+
+      @motion_event = helper.ssc(:motion_notify_event) { |this, x, y|
+        pos = get_pointed_image_pos(x, y)
+        if @draw_pos != pos
+          @draw_pos = pos
+          helper.on_modify
+        end
+        false
+      }
+
+      if @leave_sid
+        helper.signal_handler_disconnect(@leave_sid)
+        @leave_sid = nil
+      end
+
+      @leave_sid = helper.ssc(:leave_notify_event) { |this|
+        @draw_pos = nil
+        helper.on_modify
+        false
+      }
     end
 
     # コンストラクタ


### PR DESCRIPTION
画像の取得が完了した時に呼ばれる `on_image_information` メソッドは、画像取得後に呼ばれるためMiraclePainterが既に消去された後に呼ばれることがあります。

mikutterの[🎫1280](https://dev.mikutter.hachune.net/issues/1280)の修正によって今まで実行されていなかった処理が適切に実行されるようになった結果、消去されたMiraclePainterにこのプラグインがやっているような処理をするとクラッシュするようになりました。

既にmikutter側のmasterには対策を入れていてクラッシュしなくなっていますが、ともあれ消去されたMiraclePainterの描画処理をするのは意味がないので、 `on_image_information` メソッドの冒頭でreturnするようにしました。

そのさい、このメソッドの全てが単一の `if` のthen節に入ってしまったので、インデントレベルが変わってしまいますがメソッドの冒頭でreturnするように変更しました。
また、当該箇所を含めこのメソッド内で呼ぶ必要のない `Delayer.new` を消去して、メソッド全体がMiraclePainterが消えていないタイミングで実行されるようにすることで、MiraclePainterの消去チェックを一度だけで済むようにしています。