### PR TITLE
不要なmiquireの呼び出しを削除

### DIFF
--- a/mikutter-subparts-image.rb
+++ b/mikutter-subparts-image.rb
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-miquire :mui, 'sub_parts_helper'
 
 require 'gtk2'
 require 'cairo'


### PR DESCRIPTION
`miquire` は、mikutter 4.0で廃止されることになっています（ https://dev.mikutter.hachune.net/issues/1407 ）。

試したところ、このプラグインのmiquireは呼び出す必要がないので、単純に取ってしまっても互換性の問題は発生しないため、削除したほうが良いです。