### PR TITLE
モザイク化処理中にnilを踏み抜かないようにする

### DIFF
--- a/mikutter-subparts-image.rb
+++ b/mikutter-subparts-image.rb
@@ -321,7 +321,7 @@ Plugin.create :"mikutter-subparts-image" do
         # 閲覧注意画像か？
         icons = if message.respond_to?(:sensitive?) && message.sensitive? && UserConfig[:subparts_image_mozaic_sensitive]
           # モザイク画像を生成する
-      	  @main_icons.map { |_|
+      	  @main_icons.compact.map { |_|
             _.scale(16, 16).scale(_.width, _.height)
           }
         else


### PR DESCRIPTION
「閲覧注意画像をぼかして表示する」オプションを有効にしていると、時々nil objectに対してモザイク加工をしようとして落ちることがありました。

直後にある描画処理ではきちんと飛ばされていたので、同様の形にしました。